### PR TITLE
fix: harden media fetch against Safari sticky-state failures

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import ReactPlayer from "react-player";
 import { ShareSocial } from "react-share-social";
 import axios from "axios";
 import ClipLoader from "react-spinners/ClipLoader";
+import { fetchMediaWithRetry, unregisterStaleServiceWorkers } from "./lib/fetchMedia";
 import { saveAs } from "file-saver";
 import QRCode from "react-qr-code";
 import src from "./assets/cap.png";
@@ -36,6 +37,8 @@ import "./assets/css/photoShare.css";
 import qrIcon from "./assets/Group 58.png";
 function App() {
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [errorDetail, setErrorDetail] = useState("");
 
   const { shortUUID } = useParams();
 
@@ -57,71 +60,69 @@ function App() {
   };
 
   async function convertUrlToFile(url, type) {
+    if (!url) return null;
     const dataType = type == "img" ? "jpg" : "mp4";
-    const blobType = type == "img" ? "image/jpg" : "video/mp4";
-    // const response = await fetch(url,{mode: "cors"});
-    const response = await axios.get(url, {
-      responseType: "blob",
-      headers: {
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-        Pragma: "no-cache",
-        Expires: "0",
-      },
-    });
-    console.log(response.data);
-    const blob = await response.data;
-    const file = new File([blob], `media_${shortUUID}.` + dataType, {
-      type: blobType,
-    });
-    if (type == "img") {
-      setImgFile(file);
-    } else {
-      setVdoFile(file);
+    const blobType = type == "img" ? "image/jpeg" : "video/mp4";
+    try {
+      const response = await axios.get(url, { responseType: "blob" });
+      const file = new File([response.data], `media_${shortUUID}.${dataType}`, {
+        type: blobType,
+      });
+      if (type == "img") setImgFile(file);
+      else setVdoFile(file);
+      return file;
+    } catch (err) {
+      console.error(`convertUrlToFile failed for ${type}:`, err);
+      return null;
     }
-    return file;
   }
 
   const dataToApp = async () => {
-    try {
-      const result = await axios.get(
-        `${import.meta.env.VITE_APIHUB_URL}/media/${shortUUID}`
-      );
-      console.log(result)
-      const png = result.data.data.source[0].path;
-      let mp4 = "";
-      if (result?.data?.data?.source[1]?.path) {
-        mp4 = result.data.data.source[1].path;
-      } else {
-        setDisplayVideo(false);
-      }
+    const { source } = await fetchMediaWithRetry(
+      import.meta.env.VITE_APIHUB_URL,
+      shortUUID
+    );
 
-      // console.log(png);
-      setPathImg(png);
-      setPathVdo(mp4);
-      if (result?.data?.data?.source[2]?.path) {
-        const thumbnail = result.data.data.source[2].path;
-        setPathThn(thumbnail);
-      } else {
-        setPathThn(png);
-      }
+    // Classify sources by file name — never assume index-based ordering
+    const imageItem = source.find(
+      (s) => /\.(jpe?g|png|webp)$/i.test(s?.name || "") && !s.name.endsWith("_thumb.jpg")
+    );
+    const videoItem = source.find((s) =>
+      /\.(mp4|webm|mov)$/i.test(s?.name || "")
+    );
+    const thumbItem = source.find((s) => (s?.name || "").endsWith("_thumb.jpg"));
 
-      await convertUrlToFile(png, "img");
-      await convertUrlToFile(mp4, "vdo");
-      // await convertUrlToFile(thumbnail, "img");
-      // setLoading(false);
-    } catch (error) {
-      console.error(error);
-    }
+    const png = imageItem?.path || "";
+    const mp4 = videoItem?.path || "";
+
+    setPathImg(png);
+    setPathVdo(mp4);
+    setPathThn(thumbItem?.path || png);
+    setDisplayVideo(Boolean(mp4));
+
+    // Pre-fetch blobs for download/share (failures are non-fatal)
+    if (png) await convertUrlToFile(png, "img");
+    if (mp4) await convertUrlToFile(mp4, "vdo");
   };
 
   useEffect(() => {
     const goData = async () => {
+      setLoadError(false);
+      setErrorDetail("");
+      await unregisterStaleServiceWorkers();
       try {
         await dataToApp();
-
-        setLoading(false);
       } catch (error) {
-        console.error(error);
+        console.error("Failed to load media after retries:", error, error?.diagnostics);
+        setLoadError(true);
+        const diag = Array.isArray(error?.diagnostics)
+          ? error.diagnostics.map((d) =>
+              `#${d.attempt}/${d.via}: ${d.kind}${d.status ? ` [${d.status}]` : ""}${d.contentType ? ` ${d.contentType}` : ""}${d.message ? ` — ${d.message}` : ""}`
+            ).join("\n")
+          : (error?.message || "Unknown error");
+        setErrorDetail(diag);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -234,6 +235,57 @@ function App() {
               size={100}
               className="all-element-center"
             />
+          ) : loadError || (!pathImg && !pathVdo) ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                py: "8vh",
+                px: "4vw",
+                textAlign: "center",
+              }}
+            >
+              <Typography
+                color="#F4F0D3"
+                fontFamily="Boyrun"
+                fontSize="1.6em"
+                fontWeight={600}
+                sx={{ mb: "8px" }}
+              >
+                Media not found
+              </Typography>
+              <Typography color="#F4F0D3" fontFamily="Boyrun" fontSize="1em" sx={{ opacity: 0.8, mb: "20px" }}>
+                This share link may have expired or is no longer available.
+              </Typography>
+              <Button
+                variant="contained"
+                onClick={() => window.location.reload()}
+                sx={{ borderRadius: "50px", px: 4 }}
+              >
+                <Typography color="black" fontSize="1rem" fontWeight={600} textTransform="none">
+                  Try Again
+                </Typography>
+              </Button>
+              {errorDetail && (
+                <Box
+                  component="pre"
+                  sx={{
+                    mt: "20px",
+                    maxWidth: "90vw",
+                    fontSize: "0.7rem",
+                    color: "#F4F0D3",
+                    opacity: 0.6,
+                    textAlign: "left",
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
+                  {errorDetail}
+                </Box>
+              )}
+            </Box>
           ) : (
             <Grid
               item
@@ -254,10 +306,24 @@ function App() {
                 <img
                   src={pathImg}
                   alt="thumbnail"
+                  loading="lazy"
+                  decoding="async"
                   style={{
                     width: "100%",
                     height: "100%",
                     objectFit: "cover",
+                  }}
+                  onError={(e) => {
+                    const el = e.currentTarget;
+                    const attempt = Number(el.dataset.retry || 0);
+                    const backoff = [500, 1500, 3500];
+                    if (attempt < backoff.length && pathImg) {
+                      el.dataset.retry = String(attempt + 1);
+                      setTimeout(() => {
+                        const sep = pathImg.includes("?") ? "&" : "?";
+                        el.src = `${pathImg}${sep}r=${Date.now()}.${attempt + 1}`;
+                      }, backoff[attempt]);
+                    }
                   }}
                 />
                 <Box
@@ -360,10 +426,28 @@ function App() {
                   <img
                     src={pathThn || pathImg}
                     alt="video thumbnail"
+                    loading="lazy"
+                    decoding="async"
                     style={{
                       width: "100%",
                       height: "100%",
                       objectFit: "cover",
+                    }}
+                    onError={(e) => {
+                      const el = e.currentTarget;
+                      const attempt = Number(el.dataset.retry || 0);
+                      const baseSrc = pathThn || pathImg;
+                      const backoff = [500, 1500, 3500];
+                      if (attempt < backoff.length && baseSrc) {
+                        el.dataset.retry = String(attempt + 1);
+                        setTimeout(() => {
+                          const sep = baseSrc.includes("?") ? "&" : "?";
+                          el.src = `${baseSrc}${sep}r=${Date.now()}.${attempt + 1}`;
+                        }, backoff[attempt]);
+                      } else if (attempt === backoff.length && pathImg && baseSrc !== pathImg) {
+                        el.dataset.retry = String(attempt + 1);
+                        el.src = pathImg;
+                      }
                     }}
                   />
                   <Box
@@ -450,11 +534,23 @@ function App() {
                         url={vdo}
                         controls={true}
                         loop={true}
+                        playing
+                        muted
+                        playsinline
+                        config={{
+                          file: {
+                            attributes: {
+                              playsInline: true,
+                              "webkit-playsinline": "true",
+                              preload: "metadata",
+                            },
+                          },
+                        }}
                         style={{
                           maxHeight: "80vh",
                           maxWidth: "72%",
                           position: "relative",
-                          zIdex: 99,
+                          zIndex: 99,
                           marginBottom: "20px",
                         }}
                         onClick={(e) => e.stopPropagation()}
@@ -463,13 +559,10 @@ function App() {
                       <img
                         src={image}
                         alt="Selected"
+                        decoding="async"
                         style={{
                           maxHeight: "80vh",
                           maxWidth: "68%",
-                          // marginTop: "120px",
-                          // borderTop: "5px solid Darkgray",
-                          // borderLeft: "8px solid Darkgray",
-                          // borderRight: "5px solid Darkgray",
                         }}
                         onClick={(e) => e.stopPropagation()}
                       />

--- a/src/Pages/PhotoSharePage.jsx
+++ b/src/Pages/PhotoSharePage.jsx
@@ -21,6 +21,7 @@ import share from "../assets/sh.png";
 import ReactPlayer from "react-player";
 import axios from "axios";
 import ClipLoader from "react-spinners/ClipLoader";
+import { fetchMediaWithRetry, unregisterStaleServiceWorkers } from "../lib/fetchMedia";
 import { saveAs } from "file-saver";
 import QRCode from "react-qr-code";
 import src from "../assets/cap.png";
@@ -38,6 +39,7 @@ function PhotoSharePage() {
 
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [errorDetail, setErrorDetail] = useState("");
   const [mediaItems, setMediaItems] = useState([]); // [{ name, path, type, file }]
   const [selectedMedia, setSelectedMedia] = useState(null); // current item in modal
   const [showPopup, setShowPopup] = useState(false);
@@ -82,38 +84,15 @@ function PhotoSharePage() {
   }
 
   useEffect(() => {
-    const MAX_ATTEMPTS = 3;
-    const RETRY_DELAYS_MS = [500, 1500]; // delays before attempt 2 and 3
-
-    const fetchWithRetry = async () => {
-      let lastError = null;
-      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        try {
-          const result = await axios.get(
-            `${import.meta.env.VITE_APIHUB_URL}/media/${shortUUID}`,
-            { timeout: 15000 }
-          );
-          const source = Array.isArray(result?.data?.data?.source)
-            ? result.data.data.source
-            : Array.isArray(result?.data?.source)
-            ? result.data.source
-            : null;
-          if (source && source.length > 0) return source;
-          lastError = new Error("Empty or malformed response");
-        } catch (err) {
-          lastError = err;
-        }
-        if (attempt < MAX_ATTEMPTS) {
-          await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt - 1]));
-        }
-      }
-      throw lastError;
-    };
-
     const fetchData = async () => {
       setLoadError(false);
+      setErrorDetail("");
+      await unregisterStaleServiceWorkers();
       try {
-        const source = await fetchWithRetry();
+        const { source } = await fetchMediaWithRetry(
+          import.meta.env.VITE_APIHUB_URL,
+          shortUUID
+        );
 
         // Build thumbnail lookup keyed by base name (extension-agnostic)
         const thumbMap = {};
@@ -153,8 +132,15 @@ function PhotoSharePage() {
         setMediaItems(items);
         setLoading(false);
       } catch (error) {
-        console.error("Failed to load media:", error);
+        console.error("Failed to load media:", error, error?.diagnostics);
         setLoadError(true);
+        // Serialize diagnostics for on-screen debugging
+        const diag = Array.isArray(error?.diagnostics)
+          ? error.diagnostics.map((d) =>
+              `#${d.attempt}/${d.via}: ${d.kind}${d.status ? ` [${d.status}]` : ""}${d.contentType ? ` ${d.contentType}` : ""}${d.message ? ` — ${d.message}` : ""}`
+            ).join("\n")
+          : (error?.message || "Unknown error");
+        setErrorDetail(diag);
         setLoading(false);
       }
     };
@@ -249,6 +235,23 @@ function PhotoSharePage() {
                   Try Again
                 </Typography>
               </Button>
+              {errorDetail && (
+                <Box
+                  component="pre"
+                  sx={{
+                    mt: "20px",
+                    maxWidth: "90vw",
+                    fontSize: "0.7rem",
+                    color: "#F4F0D3",
+                    opacity: 0.6,
+                    textAlign: "left",
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
+                  {errorDetail}
+                </Box>
+              )}
             </Box>
           ) : (
             <Grid item size={{ xs: 12, md: 12 }} container spacing={2} className="all-element-center">
@@ -263,7 +266,7 @@ function PhotoSharePage() {
                     border: "12px solid #F4F0D3",
                   }}
                 >
-                  {/* Thumbnail — image-only, with retry on transient Safari fetch failures */}
+                  {/* Thumbnail — image-only, with exponential retry on Safari fetch failures */}
                   <img
                     src={item.thumbnail}
                     alt={item.label}
@@ -273,10 +276,13 @@ function PhotoSharePage() {
                     onError={(e) => {
                       const el = e.currentTarget;
                       const attempt = Number(el.dataset.retry || 0);
-                      if (attempt < 1 && item.thumbnail) {
+                      const backoff = [500, 1500, 3500];
+                      if (attempt < backoff.length && item.thumbnail) {
                         el.dataset.retry = String(attempt + 1);
-                        const sep = item.thumbnail.includes("?") ? "&" : "?";
-                        el.src = `${item.thumbnail}${sep}r=${Date.now()}`;
+                        setTimeout(() => {
+                          const sep = item.thumbnail.includes("?") ? "&" : "?";
+                          el.src = `${item.thumbnail}${sep}r=${Date.now()}.${attempt + 1}`;
+                        }, backoff[attempt]);
                       }
                     }}
                   />

--- a/src/lib/fetchMedia.js
+++ b/src/lib/fetchMedia.js
@@ -1,0 +1,138 @@
+// Hardened media fetch: cache-bust every attempt, detect string/HTML responses,
+// fall back to native fetch if axios fails, capture diagnostic info.
+import axios from "axios";
+
+const MAX_ATTEMPTS = 4;
+const RETRY_DELAYS_MS = [400, 1200, 3000]; // before attempts 2, 3, 4
+
+/**
+ * @param {string} apiBase - VITE_APIHUB_URL
+ * @param {string} shortUUID
+ * @returns {Promise<{ source: Array, diagnostics: Array }>}
+ */
+export async function fetchMediaWithRetry(apiBase, shortUUID) {
+  const diagnostics = [];
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const cacheBuster = `_cb=${Date.now()}.${attempt}`;
+    const url = `${apiBase}/media/${shortUUID}?${cacheBuster}`;
+    const via = attempt <= 2 ? "axios" : "fetch"; // escalate transport after 2 axios tries
+
+    try {
+      const { data, status, contentType } = await (via === "axios"
+        ? requestViaAxios(url)
+        : requestViaFetch(url));
+
+      // Guard: if server returned HTML / text (WAF block page, captive portal, redirect)
+      if (typeof data === "string") {
+        diagnostics.push({ attempt, via, status, contentType, kind: "string-response", preview: data.slice(0, 120) });
+        throw new Error(`Non-JSON response (${contentType})`);
+      }
+
+      const source = pickSource(data);
+      if (source && source.length > 0) {
+        return { source, diagnostics };
+      }
+
+      diagnostics.push({ attempt, via, status, contentType, kind: "empty-source", bodyKeys: data && typeof data === "object" ? Object.keys(data) : [] });
+    } catch (err) {
+      diagnostics.push({ attempt, via, kind: "error", message: err?.message || String(err), status: err?.response?.status });
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(RETRY_DELAYS_MS[attempt - 1] ?? 2000);
+    }
+  }
+
+  const err = new Error("All retry attempts exhausted");
+  err.diagnostics = diagnostics;
+  throw err;
+}
+
+function pickSource(data) {
+  if (Array.isArray(data?.data?.source)) return data.data.source;
+  if (Array.isArray(data?.source)) return data.source;
+  if (Array.isArray(data?.data)) return data.data;
+  return null;
+}
+
+async function requestViaAxios(url) {
+  const res = await axios.get(url, {
+    timeout: 12000,
+    headers: {
+      Accept: "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    // Force axios to reject non-2xx rather than returning the error body as data
+    validateStatus: (s) => s >= 200 && s < 300,
+    transformResponse: [(body) => {
+      // Try to parse; if not JSON, leave as string so caller can detect
+      if (typeof body !== "string") return body;
+      try {
+        return JSON.parse(body);
+      } catch {
+        return body;
+      }
+    }],
+  });
+  return {
+    data: res.data,
+    status: res.status,
+    contentType: res.headers?.["content-type"] || "",
+  };
+}
+
+async function requestViaFetch(url) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 12000);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      cache: "no-store",
+      credentials: "omit",
+      headers: {
+        Accept: "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      signal: controller.signal,
+    });
+    const contentType = res.headers.get("content-type") || "";
+    const text = await res.text();
+    if (!res.ok) {
+      const err = new Error(`HTTP ${res.status}`);
+      err.response = { status: res.status };
+      throw err;
+    }
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+    return { data, status: res.status, contentType };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Unregister any stale service workers and purge caches. Called once on mount.
+ * Safari sometimes keeps old SWs alive that intercept API calls.
+ */
+export async function unregisterStaleServiceWorkers() {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+  try {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map((r) => r.unregister()));
+    if (typeof caches !== "undefined" && caches.keys) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } catch {
+    // best-effort; ignore
+  }
+}


### PR DESCRIPTION
## Summary
- New `src/lib/fetchMedia.js` helper: 4 attempts with cache-busting query param on every call, transport escalation from axios to native `fetch` (with `cache: 'no-store'`), explicit `Accept: application/json`, string-response guard that treats HTML/WAF pages as retriable failures, and per-attempt diagnostics captured on the thrown error.
- Unregister stale service workers + purge Cache Storage on mount of `/media/:shortUUID` and `/photoshare/:shortUUID` so old SWs can't intercept API calls.
- Thumbnail `onError` now retries 3 times with exponential backoff (500/1500/3500 ms) instead of once — handles Safari HTTP/2 stream drops.
- "Media not found" screen shows serialized diagnostics (transport, HTTP status, content-type, error message per attempt) so future failures can be debugged from a user's screenshot.
- Same treatment applied to both `App.jsx` (legacy media page) and `PhotoSharePage.jsx`.

## Why
Users reported that on Safari (same iOS version, different devices) media randomly fails to load — sometimes the API call itself, sometimes the S3 images. Symptoms included `TypeError: undefined is not an object (evaluating '...data.data.source')` when Safari received an HTML response (stale cache / WAF / captive portal) that axios stored as a string. Simple retry didn't help because the cause is sticky per-session (cached response, stale SW, HTTP/2 connection reuse). Cache-busting + transport escalation + SW purge breaks that stickiness.

## Test plan
- [ ] Open `/photoshare/<shortUUID>` on Safari iOS — thumbnails load, video modal autoplays (muted), download/share work
- [ ] Open the same URL in Chrome — no regression
- [ ] Throttle network / Airplane-mode-toggle mid-load — retries fire and eventually succeed or show the diagnostic Not Found screen
- [ ] Force-break the API (bad shortUUID) — Not Found screen appears with per-attempt diagnostics
- [ ] Verify no old service worker persists after first visit on the new build

## Known non-blockers
- GitHub Dependabot reports pre-existing vulnerabilities on `main` — unrelated to this PR, worth addressing separately.